### PR TITLE
fix: Improve progress output timing

### DIFF
--- a/src/execution.rs
+++ b/src/execution.rs
@@ -88,6 +88,7 @@ impl<'t> Task<'t> {
                 feature_set,
                 Cyan.paint("]")
             );
+            std::io::stdout().flush().expect("failed to flush stdout");
 
             let on_success =
                 || println!("{}", Black.style().bg(Green).paint("OK"));


### PR DESCRIPTION
The output showing the command and configuration is printed using print!() before the command is executed. However, on systems which are line-buffered, that output is not actually displayed until after a newline is printed -- which happens here when the results of the command are retrieved and the OK or Fail message is printed.

This commit adds a call to std::io::stdout::flush() to make the first part of the output (showing command and configuration) actually get printed to the display immediately, without waiting for the command to complete.

This does not change the content or formatting of the output; only the timing of the output is changed.  This closes #4