### PR TITLE
fix: Use --no-default-features for executed commands

### DIFF
--- a/src/execution.rs
+++ b/src/execution.rs
@@ -64,6 +64,7 @@ impl<'t> Task<'t> {
                     .args(self.args.iter())
                     .stderr(Stdio::piped())
                     .stdout(Stdio::piped())
+                    .arg("--no-default-features")
                     .arg("--package")
                     .arg(self.package_name);
 

--- a/tests/samples/features/Cargo.toml
+++ b/tests/samples/features/Cargo.toml
@@ -11,4 +11,4 @@ feat-z = []
 
 [dependencies]
 serde = { version = "1.0.130", optional = true }
-rand = "0.1.0"
+rand = "0.8.5"

--- a/tests/samples/seed/Cargo.toml
+++ b/tests/samples/seed/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [features]
+default = [ "feat-c" ]
 feat-a = []
 feat-b = []
 feat-c = []

--- a/tests/samples/seed/src/lib.rs
+++ b/tests/samples/seed/src/lib.rs
@@ -5,4 +5,7 @@ mod tests {
         let result = 2 + 2;
         assert_eq!(result, 4);
     }
+
+    #[cfg(feature = "feat-c")]
+    compile_error!("Default feat-c NOT disabled");
 }

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -30,6 +30,32 @@ fn test() {
     });
 }
 
+#[test]
+fn test_no_default_features() {
+    glob!("samples/seed/Cargo.toml", |path| {
+        let path = path
+            .parent()
+            .expect("failed to unwrap parent of Cargo.toml");
+
+        let mut cmd = Command::new(BIN.as_os_str());
+        let assert = cmd
+            .arg("feature-matrix")
+            .arg("--color=never")
+            .arg("test")
+            .current_dir(path)
+            .assert()
+            .success();
+        let output = assert.get_output();
+        let output = std::str::from_utf8(&output.stdout)
+            .expect("child process's output included invalid unicode");
+
+        with_settings!({snapshot_suffix => path.file_name().unwrap().to_str().unwrap()},
+        {
+            assert_snapshot!(output);
+        });
+    });
+}
+
 lazy_static! {
     static ref BIN: PathBuf =
         assert_cmd::cargo::cargo_bin("cargo-feature-matrix");

--- a/tests/snapshots/snapshot__no_default_features@seed.snap
+++ b/tests/snapshots/snapshot__no_default_features@seed.snap
@@ -1,0 +1,10 @@
+---
+source: tests/snapshot.rs
+expression: output
+
+---
+running: cmd=test package=sample features=[]......OK
+running: cmd=test package=sample features=[feat-a]......OK
+running: cmd=test package=sample features=[feat-a,feat-b]......OK
+running: cmd=test package=sample features=[feat-b]......OK
+

--- a/tests/snapshots/snapshot__no_default_features@seed.snap
+++ b/tests/snapshots/snapshot__no_default_features@seed.snap
@@ -7,4 +7,3 @@ running: cmd=test package=sample features=[]......OK
 running: cmd=test package=sample features=[feat-a]......OK
 running: cmd=test package=sample features=[feat-a,feat-b]......OK
 running: cmd=test package=sample features=[feat-b]......OK
-


### PR DESCRIPTION
If --no-default-features is NOT used, the the selected features used in a given build are those selected by cargo-feature-matrix PLUS the default features.   This is contrary to the UI output and likely contrary to the desired behavior of a test matrix.

This commit unconditionally adds --no-default-features to the command arguments.  A new test case is also added which will fail if the default features are not properly suppressed.

Along the way, the `features` sample was updated to use a new version of `rand`, as the version specified doesn't actually compile with a current stable compiler.

This fixes #3 